### PR TITLE
Add server identifier option converter

### DIFF
--- a/lib/packet/converters.js
+++ b/lib/packet/converters.js
@@ -241,6 +241,14 @@ var converters = {
     }
   },
 
+  // option 54: server identifier
+  54: {
+    encode: utils.writeIp,
+    decode: function decode(buf) {
+      return utils.readIp(buf);
+    }
+  },
+
   // option 55: parameter request list
   55: {
     decode: function decode(buf) {


### PR DESCRIPTION
The converter (at least the decoder) is needed so that the server can determine if the offer from this or some other server has been accepted by the client. See chapter 9.7 of http://tools.ietf.org/html/rfc2132  as well as page 13/DHCPREQUEST of https://www.ietf.org/rfc/rfc2131.txt .
